### PR TITLE
Basic notifications are working

### DIFF
--- a/app/javascript/channels/room.js
+++ b/app/javascript/channels/room.js
@@ -1,5 +1,18 @@
 let App =  require('../cable');
 
+function notifySongChange(track){
+  if(Notification.permission != "granted"){
+    Notification.requestPermission();
+  }
+  if(Notification.permission == "granted"){
+    let notification = new Notification("Now Playing", {
+      body:  `${track.title} - ${track.details.album.name}`,
+      tag: track.uri,
+      icon: track.details.album.images[0],
+    });
+  }
+}
+
 App.room = App.cable.subscriptions.create('RoomChannel', {
   connected: function() {},
   disconnected: function() {},
@@ -10,6 +23,8 @@ App.room = App.cable.subscriptions.create('RoomChannel', {
       case 'nowplaying_change':
         // This does nothing if #now_playing isn't on the page, which is nice.
         $('#now_playing').load('/home/nowplaying');
+        // But we still may want to see that a song changed:
+        notifySongChange(JSON.parse(msg.track));
         break;
       default:
         console.log('Unknown event from room:', msg);

--- a/lib/tasks/spinner.rake
+++ b/lib/tasks/spinner.rake
@@ -59,6 +59,7 @@ namespace :spinner do
                 # Tell everyone the current song playing changed.
                 ActionCable.server.broadcast('room_channel', {
                   event: 'nowplaying_change',
+                  track: qe.track.to_json() 
                 })
               end
             end


### PR DESCRIPTION
This should close #20 

The qe.track.to_json is a bit lazy, we could send only the details we care about but it works